### PR TITLE
Fixing token verification issues with sdk mfa flow

### DIFF
--- a/activities/tokens/getTokensFromMultifactorTokenActivity.ts
+++ b/activities/tokens/getTokensFromMultifactorTokenActivity.ts
@@ -51,17 +51,17 @@ export async function getTokensFromMultifactorTokenActivity(
 	const otpSecret = decrypt(userAccount.otpSecret)
 	if (!otpSecret) {
 		throw new GrayskullError(GrayskullErrorCode.NotAuthorized, `Failed to decrypt otp secret`)
-	} else {
-		if (
-			!verifyOtpTokenActivity(otpSecret, otpToken) &&
-			!(await verifyBackupMultifactorCode(
-				(challengeTokenObject as IChallengeToken).emailAddress,
-				otpToken,
-				context.dataContext
-			))
-		) {
-			throw new GrayskullError(GrayskullErrorCode.InvalidOTP, `Token is incorrect`)
-		}
+	}
+
+	if (
+		!verifyOtpTokenActivity(otpSecret, otpToken) &&
+		!(await verifyBackupMultifactorCode(
+			(challengeTokenObject as IChallengeToken).emailAddress,
+			otpToken,
+			context.dataContext
+		))
+	) {
+		throw new GrayskullError(GrayskullErrorCode.InvalidOTP, `Token is incorrect`)
 	}
 
 	return getTokensActivity(

--- a/pages/api/token.tsx
+++ b/pages/api/token.tsx
@@ -147,7 +147,7 @@ export default async function handleTokenRequest(req: NextApiRequest, res: NextA
 				}
 				case GrayskullErrorCode.InvalidOTP: {
 					res.status(400).json(new OauthError('invalid_request', 'Failed to verify multifactor_token'))
-					break
+					return
 				}
 			}
 		}


### PR DESCRIPTION
Fixes a couple of issues with the sdk mfa flow.

- Parameters were passed in the wrong order
- Users OTP secret token was not being decrypted
- GrayskullErrorCode.InvalidOTP was not returning, so it was trying to set the res headers twice which killed the server.