### PR TITLE
Bug/keep login query state

### DIFF
--- a/activities/admin/createUserAccountActivity.spec.ts
+++ b/activities/admin/createUserAccountActivity.spec.ts
@@ -74,7 +74,7 @@ describe('createUserAccountActivity', () => {
 				user: { permissions: Permissions.Admin }
 			} as IRequestContext)
 			const email = await getEmailAddressByEmailAddress('test1@testemail.com', dataContext)
-			isVerified = email?.verified
+			isVerified = email && email.verified
 		} catch (error) {
 			isVerified = false
 		}
@@ -93,7 +93,7 @@ describe('createUserAccountActivity', () => {
 				configuration: { Server: { baseUrl: 'http://localhost:5000' } }
 			} as IRequestContext)
 			const email = await getEmailAddressByEmailAddress('testnopassword@exmaple.com', dataContext)
-			isVerified = email?.verified
+			isVerified = email && email.verified
 		} catch (error) {
 			isVerified = false
 		}

--- a/presentation/utils/createApolloClient.ts
+++ b/presentation/utils/createApolloClient.ts
@@ -34,6 +34,7 @@ export default function createApolloClient() {
 					return
 				}
 			})
+
 			graphQLErrors.map(({ message, locations, path }) => {
 				console.error(`[GraphQL error]: Message: ${message}, Location: ${locations}, Path: ${path}`)
 			})

--- a/presentation/utils/createApolloClient.ts
+++ b/presentation/utils/createApolloClient.ts
@@ -4,6 +4,7 @@ import { InMemoryCache } from 'apollo-cache-inmemory'
 import { onError } from 'apollo-link-error'
 import { ApolloLink, Observable } from 'apollo-link'
 import { createUploadLink } from 'apollo-upload-client'
+import btoa from 'btoa'
 
 export default function createApolloClient() {
 	const onErrorHandler = onError(({ graphQLErrors, networkError }) => {
@@ -17,14 +18,22 @@ export default function createApolloClient() {
 					window.location.pathname !== '/login' &&
 					window.location.pathname !== '/register'
 				) {
-					window.location.replace('/login')
+					const query = new URLSearchParams(window.location.search).toString()
+					const pathname = window.location.pathname
+					const state = btoa(
+						JSON.stringify({
+							pathname,
+							query
+						})
+					)
+					const loginUrl = `/login?state=${state}`
+					window.location.replace(loginUrl)
 				}
 				if (err.extensions && err.extensions.code === 'FORBIDDEN' && window.location.pathname !== '/oobe') {
 					window.location.replace('/oobe')
 					return
 				}
 			})
-
 			graphQLErrors.map(({ message, locations, path }) => {
 				console.error(`[GraphQL error]: Message: ${message}, Location: ${locations}, Path: ${path}`)
 			})


### PR DESCRIPTION
# Issue
resolves #307 
- There was an issue when redirecting a user to the Grayskull `/authenticate` page while not being logged in. It would redirect the user to the `/login` page but would remove the query parameters that were sent in the URL. This caused the user to not be redirected back to the location specified in the `redirect_uri` value.
  
# Things Done
- Added logic to grab the query params and format them in the `state` string value so after login we know where to redirect the user.
- Quickly fixed a test that was failing due to an issue with babel not recognizing / allowing optional chaining in Jest. Looks like it is fairly simple to solve, I will create a new issue. ref: https://github.com/facebook/jest/issues/8973
  
# How to Test
- **How I tested locally for time-entry:**
  - Run Grayskull locally and add client information for my local time-entry app
  - Add the necessary query params to the Grayskull `/authorize` url
  - Configure local time-entry app to redirect user to my local Grayskull instance using the client information I created in local Grayskull
  - Login and verify that the `state` query param exists in the url and verify I am redirected to the `redirect_uri` location
  
## _Note_
### Should probably test the other internal applications that currently use this flow just to verify there are no breaking changes.
