### PR TITLE
Bug/keep login query state

### DIFF
--- a/pages/login.js
+++ b/pages/login.js
@@ -18,7 +18,8 @@ class LoginPage extends React.PureComponent {
 		if (this.props.router.query.state) {
 			const parsedState = parseRoutingState(this.props.router.query.state)
 			if (parsedState) {
-				this.props.router.push(parsedState)
+				const authUrl = `${parsedState.pathname}?${parsedState.query}`
+				this.props.router.push(authUrl, authUrl)
 				return
 			}
 		}

--- a/presentation/components/RequireAuthentication.js
+++ b/presentation/components/RequireAuthentication.js
@@ -17,7 +17,7 @@ class RequireAuthentication extends Component {
 				{({ user, hasInitialized }) => {
 					if (!user && hasInitialized) {
 						const state = generateRoutingState(this.props.router)
-						Router.push(`/login?state=${state}`)
+						Router.push(`/login?state=${state}`, `/login?state=${state}`)
 					} else {
 						if (!hasInitialized) {
 							return <LoadingIndicator message="Loading..." />

--- a/presentation/utils/createApolloClient.ts
+++ b/presentation/utils/createApolloClient.ts
@@ -34,7 +34,6 @@ export default function createApolloClient() {
 					return
 				}
 			})
-
 			graphQLErrors.map(({ message, locations, path }) => {
 				console.error(`[GraphQL error]: Message: ${message}, Location: ${locations}, Path: ${path}`)
 			})

--- a/presentation/utils/createApolloClient.ts
+++ b/presentation/utils/createApolloClient.ts
@@ -34,6 +34,7 @@ export default function createApolloClient() {
 					return
 				}
 			})
+
 			graphQLErrors.map(({ message, locations, path }) => {
 				console.error(`[GraphQL error]: Message: ${message}, Location: ${locations}, Path: ${path}`)
 			})


### PR DESCRIPTION
# Related Issues
- resolves #307 
- connects with #306 
# Things Done
- Added an `as` argument to the `router.push()` methods.
# How to Test
- See #306

---  
  
When using Next/Router `router.push()` with query params, you have to pass the second `as` optional argument and add the query params to both arguments. If not, it will strip the query params from the `router.push()` and push to just the path. I think Next added this information to the documentation after this was implemented in Grayskull.

ref: 
- https://github.com/vercel/next.js/issues/9574 
- https://github.com/vercel/next.js/issues/9473
