### PR TITLE
Fix issue with state being in wrong format in /authorize

### DIFF
--- a/pages/login.js
+++ b/pages/login.js
@@ -4,7 +4,7 @@ import BackgroundCover from '../presentation/components/BackgroundCover'
 import RequireConfiguration from '../presentation/components/RequireConfiguration'
 import LoginForm from '../presentation/components/LoginForm'
 import Primary from '../presentation/layouts/primary'
-import { parseRoutingState } from '../presentation/utils/routing'
+import { parseRoutingState, parseQueryParams } from '../presentation/utils/routing'
 import UserContext from '../presentation/contexts/UserContext'
 
 class LoginPage extends React.PureComponent {
@@ -17,8 +17,9 @@ class LoginPage extends React.PureComponent {
 		await this.refresh()
 		if (this.props.router.query.state) {
 			const parsedState = parseRoutingState(this.props.router.query.state)
+			const queryString = parseQueryParams(parsedState.query)
 			if (parsedState) {
-				const authUrl = `${parsedState.pathname}?${parsedState.query}`
+				const authUrl = `${parsedState.pathname}?${queryString}`
 				this.props.router.push(authUrl, authUrl)
 				return
 			}

--- a/presentation/utils/routing.js
+++ b/presentation/utils/routing.js
@@ -12,3 +12,20 @@ export function generateRoutingState({ pathname, query }) {
 export function parseRoutingState(state) {
 	return JSON.parse(atob(state))
 }
+
+export function parseQueryParams(query) {
+	if (typeof query === 'string') return query
+
+	const queryLength = Object.keys(query).length
+	let current = 1
+	let queryString = ''
+	for (const param of Object.keys(query)) {
+		if (param === 'scope') {
+			queryString += `${param}=${encodeURIComponent(query[param])}${current < queryLength ? '&' : ''}`
+		} else {
+			queryString += `${param}=${query[param]}${current < queryLength ? '&' : ''}`
+		}
+		current++
+	}
+	return queryString
+}


### PR DESCRIPTION
# Related Issues
- resolves #312 
# Things Done
- Seems the query state can exist as a string and an object. I was only handling the state in string form so now I am handling both cases.
# How to Test
- 
