### PR TITLE
Fixing issue with response types in an array separated with comma

### DIFF
--- a/communication/graphql/UserAccount/authorizeClientResolver.ts
+++ b/communication/graphql/UserAccount/authorizeClientResolver.ts
@@ -27,7 +27,7 @@ export async function authorizeClientResolver(obj, args, context: IRequestContex
 			pendingScopes
 		}
 	}
-	const responseTypes: string[] = responseType.split(' ')
+	const responseTypes: string[] = responseType.indexOf(',') > -1 ? responseType.split(',') : responseType.split(' ')
 
 	const authorizationUrl = await generateAuthorizationRedirectActivity(
 		client_id,


### PR DESCRIPTION
# Related Issues
- resolves #315 
# Things Done
- Checking if the response type parameter has a comma first. If it does, split on the comma, if not split on space like before. This ensures that if any legacy application was working with the previous logic it should still work while solving the issue moving forward.
# How to Test
- 
