### PR TITLE
Fixing users permission mutation bug

### DIFF
--- a/presentation/components/EditableUserProfile.tsx
+++ b/presentation/components/EditableUserProfile.tsx
@@ -107,6 +107,11 @@ export interface EditableUserProfileState {
 	fromAdmin: boolean
 }
 
+interface PermissionOptions {
+	label: string
+	value: number
+}
+
 export default class EditableUserProfile extends React.Component<EditableUserProfileProps, EditableUserProfileState> {
 	constructor(props: EditableUserProfileProps) {
 		super(props)
@@ -122,8 +127,10 @@ export default class EditableUserProfile extends React.Component<EditableUserPro
 	}
 
 	public handleChange = (e: React.ChangeEvent<HTMLInputElement>, validate: any) => {
+		const permissionValue =
+			e.target.name === 'permissions' ? ((e.target.value as unknown) as PermissionOptions).value : undefined
 		const currentState = this.state.modifiedState
-		currentState[e.target.name] = e.target.value
+		currentState[e.target.name] = permissionValue ? permissionValue : e.target.value
 		this.setState({ modifiedState: currentState })
 		validate()
 	}
@@ -150,7 +157,7 @@ export default class EditableUserProfile extends React.Component<EditableUserPro
 			validations.push(new FormValidationRule('emailAddress', 'isEmpty', false, 'Email Address is required'))
 		}
 
-		const permissionOptions = [
+		const permissionOptions: PermissionOptions[] = [
 			{
 				label: 'User',
 				value: Permissions.USER
@@ -160,8 +167,8 @@ export default class EditableUserProfile extends React.Component<EditableUserPro
 				value: Permissions.ADMIN
 			}
 		]
-		const selectedPermission =
-			finalUser.permissions.value === Permissions.ADMIN ? permissionOptions[1] : permissionOptions[0]
+		const finalUserPermissions = this.state.editing ? finalUser.permissions : finalUser.permissions.value
+		const selectedPermission = finalUserPermissions === Permissions.ADMIN ? permissionOptions[1] : permissionOptions[0]
 
 		const genderOptions = ['Male', 'Female']
 		if (finalUser.gender && genderOptions.includes(finalUser.gender) === false) {


### PR DESCRIPTION
# Related Issues
- resolves #320 
# Things Done
- #276 Fixed the UI for permissions, but broke the graphql mutation call.
- The `finalUser` state object while being edited, has only the permissions number value under `finalUser.permissions` while the create user / update user UI has the full permissions object so: `finalUser.permissions.value`
- Fixed by checking to see if the user is being edited or not. If it is use `finalUser.permissions` else use `finalUser.permissions.value` 
# How to Test
- _**As an admin user**_ 
  - Go to the `users` section 
  - Select a user 
  - Change their role with the dropdown (ensure the UI value updates)
  - Click `Save Info` button and verify the users role has been updated after page refresh
  
### Additional notes:
- This is a quick fix without having to change much code
- Eventually, as a cleaner solution - it may be a better idea to revisit how we are saving the users permissions, or adjust the permissions object initially after retrieving the user from the DB further up the component tree.
